### PR TITLE
Slider (issue with 0.1 increment size)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "range-slider",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "author": "Adalo",
   "license": "MIT",
   "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "range-slider",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "author": "Adalo",
   "license": "MIT",
   "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "range-slider",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "author": "Adalo",
   "license": "MIT",
   "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "range-slider",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "author": "Adalo",
   "license": "MIT",
   "main": "index.js",

--- a/src/components/RangeSlider/CustomLabel.js
+++ b/src/components/RangeSlider/CustomLabel.js
@@ -56,7 +56,7 @@ class CustomLabel extends Component {
       leftDiff,
       oneMarkerValue,
       oneMarkerLeftPosition,
-      oneMarkerPressed,
+      oneMarkerPressed
     } = this.props
 
     const { bgColor, font, txtColor, labelRounding } = this.props

--- a/src/components/RangeSlider/CustomLabel.js
+++ b/src/components/RangeSlider/CustomLabel.js
@@ -60,7 +60,7 @@ class CustomLabel extends Component {
       roundLabelValue
     } = this.props
 
-    const roundedMarkerValue = roundLabelValue(oneMarkerValue)
+    const roundedValue = roundLabelValue(oneMarkerValue)
 
     const { bgColor, font, txtColor, labelRounding } = this.props
     return (
@@ -72,7 +72,7 @@ class CustomLabel extends Component {
           font={font}
           labelRounding={labelRounding}
           position={oneMarkerLeftPosition}
-          value={roundedMarkerValue}
+          value={roundedValue}
           leftDiff={leftDiff}
           pressed={oneMarkerPressed}
         />

--- a/src/components/RangeSlider/CustomLabel.js
+++ b/src/components/RangeSlider/CustomLabel.js
@@ -57,10 +57,7 @@ class CustomLabel extends Component {
       oneMarkerValue,
       oneMarkerLeftPosition,
       oneMarkerPressed,
-      roundLabelValue
     } = this.props
-
-    const roundedValue = roundLabelValue(oneMarkerValue)
 
     const { bgColor, font, txtColor, labelRounding } = this.props
     return (
@@ -72,7 +69,7 @@ class CustomLabel extends Component {
           font={font}
           labelRounding={labelRounding}
           position={oneMarkerLeftPosition}
-          value={roundedValue}
+          value={oneMarkerValue}
           leftDiff={leftDiff}
           pressed={oneMarkerPressed}
         />

--- a/src/components/RangeSlider/CustomLabel.js
+++ b/src/components/RangeSlider/CustomLabel.js
@@ -57,7 +57,11 @@ class CustomLabel extends Component {
       oneMarkerValue,
       oneMarkerLeftPosition,
       oneMarkerPressed,
+      roundLabelValue
     } = this.props
+
+    const roundedMarkerValue = roundLabelValue(oneMarkerValue)
+
     const { bgColor, font, txtColor, labelRounding } = this.props
     return (
       <View style={{ position: 'relative' }}>
@@ -68,7 +72,7 @@ class CustomLabel extends Component {
           font={font}
           labelRounding={labelRounding}
           position={oneMarkerLeftPosition}
-          value={oneMarkerValue}
+          value={roundedMarkerValue}
           leftDiff={leftDiff}
           pressed={oneMarkerPressed}
         />

--- a/src/components/RangeSlider/index.js
+++ b/src/components/RangeSlider/index.js
@@ -21,11 +21,14 @@ class RangeSlider extends Component {
       incrementSize
     } = this.props
 
+    // precision function => obtains number of digits after decimal point of incrementSize
     if (!isFinite(incrementSize) || incrementSize <= 0) return value;
-    var e = 1, p = 0;
-    while (Math.round(incrementSize * e) / e !== incrementSize) { e *= 10; p++; }
+    let multiplier = 1, precision = 0;
+    while (Math.round(incrementSize * multiplier) / multiplier !== incrementSize) { 
+      multiplier *= 10; precision++; 
+    }
 
-    var finalValue = parseFloat(value.toFixed(p))
+    let finalValue = parseFloat(value.toFixed(precision))
     return finalValue;
   }
 

--- a/src/components/RangeSlider/index.js
+++ b/src/components/RangeSlider/index.js
@@ -16,13 +16,28 @@ class RangeSlider extends Component {
     }
   }
 
+  roundLabelValue = value => {
+    const {
+      incrementSize
+    } = this.props
+
+    if (!isFinite(incrementSize)) return 0;
+    var e = 1, p = 0;
+    while (Math.round(incrementSize * e) / e !== incrementSize) { e *= 10; p++; }
+
+    var finalValue = parseFloat(value.toFixed(p))
+    return finalValue;
+  }
+
   sliderValuesChange = values => {
     // database onchange props
     const {
-      controlledValue: { onChange },
+      controlledValue: { onChange }
     } = this.props
 
-    return onChange(values[0])
+    const finalValue = this.roundLabelValue(values[0])
+
+    return onChange(finalValue)
   }
 
   render() {
@@ -61,6 +76,9 @@ class RangeSlider extends Component {
     const padding = Math.ceil(markerSize / 2)
     const paddingStyles = { paddingLeft: padding, paddingRight: padding }
     const sliderLength = width - padding * 2
+
+    console.log("LABELS", [trackValue])
+    console.log("INCREMENT SIZE GIVEN", incrementSize)
 
     return (
       <View
@@ -114,6 +132,7 @@ class RangeSlider extends Component {
                     ? track.styles.bodyFont
                     : { fontFamily: _fonts.body }
                 }
+                roundLabelValue={this.roundLabelValue}
               />
             )}
             // database

--- a/src/components/RangeSlider/index.js
+++ b/src/components/RangeSlider/index.js
@@ -21,6 +21,8 @@ class RangeSlider extends Component {
       incrementSize
     } = this.props
 
+    if (!value) return value;
+
     // precision function => obtains number of digits after decimal point of incrementSize
     if (!isFinite(incrementSize) || incrementSize <= 0) return value;
     let multiplier = 1
@@ -29,8 +31,8 @@ class RangeSlider extends Component {
       multiplier *= 10 
       precision++
     }
-
-    let finalValue = parseFloat(value.toFixed(precision))
+    
+    let finalValue = parseFloat(parseFloat(value).toFixed(precision))
     return finalValue;
   }
 
@@ -123,7 +125,7 @@ class RangeSlider extends Component {
             // labels
             enableLabel={enabled}
             customLabel={props => {
-              let { oneMarkerValue } = props
+              let { oneMarkerValue } = props 
               oneMarkerValue = this.roundLabelValue(oneMarkerValue)
 
               return (
@@ -139,6 +141,7 @@ class RangeSlider extends Component {
                       ? track.styles.bodyFont
                       : { fontFamily: _fonts.body }
                   }
+                  roundLabelValue={this.roundLabelValue}
                 />
               )
             }}

--- a/src/components/RangeSlider/index.js
+++ b/src/components/RangeSlider/index.js
@@ -76,10 +76,7 @@ class RangeSlider extends Component {
     const padding = Math.ceil(markerSize / 2)
     const paddingStyles = { paddingLeft: padding, paddingRight: padding }
     const sliderLength = width - padding * 2
-
-    console.log("LABELS", [trackValue])
-    console.log("INCREMENT SIZE GIVEN", incrementSize)
-
+    
     return (
       <View
         style={[styles.wrapper, paddingStyles]}

--- a/src/components/RangeSlider/index.js
+++ b/src/components/RangeSlider/index.js
@@ -122,21 +122,27 @@ class RangeSlider extends Component {
             )}
             // labels
             enableLabel={enabled}
-            customLabel={props => (
-              <CustomLabel
-                {...props}
-                bgColor={bgColor}
-                txtColor={txtColor}
-                font={font}
-                labelRounding={labelRounding}
-                bodyFont={
-                  track.styles
-                    ? track.styles.bodyFont
-                    : { fontFamily: _fonts.body }
-                }
-                roundLabelValue={this.roundLabelValue}
-              />
-            )}
+            customLabel={props => {
+              let { oneMarkerValue } = props
+              oneMarkerValue = this.roundLabelValue(oneMarkerValue)
+
+              return (
+                <CustomLabel
+                  {...props}
+                  oneMarkerValue={oneMarkerValue}
+                  bgColor={bgColor}
+                  txtColor={txtColor}
+                  font={font}
+                  labelRounding={labelRounding}
+                  bodyFont={
+                    track.styles
+                      ? track.styles.bodyFont
+                      : { fontFamily: _fonts.body }
+                  }
+                  roundLabelValue={this.roundLabelValue}
+                />
+              )
+            }}
             // database
             onValuesChangeFinish={this.sliderValuesChange}
             sliderLength={sliderLength}

--- a/src/components/RangeSlider/index.js
+++ b/src/components/RangeSlider/index.js
@@ -139,7 +139,6 @@ class RangeSlider extends Component {
                       ? track.styles.bodyFont
                       : { fontFamily: _fonts.body }
                   }
-                  roundLabelValue={this.roundLabelValue}
                 />
               )
             }}

--- a/src/components/RangeSlider/index.js
+++ b/src/components/RangeSlider/index.js
@@ -23,9 +23,11 @@ class RangeSlider extends Component {
 
     // precision function => obtains number of digits after decimal point of incrementSize
     if (!isFinite(incrementSize) || incrementSize <= 0) return value;
-    let multiplier = 1, precision = 0;
+    let multiplier = 1
+    let precision = 0
     while (Math.round(incrementSize * multiplier) / multiplier !== incrementSize) { 
-      multiplier *= 10; precision++; 
+      multiplier *= 10 
+      precision++
     }
 
     let finalValue = parseFloat(value.toFixed(precision))

--- a/src/components/RangeSlider/index.js
+++ b/src/components/RangeSlider/index.js
@@ -21,7 +21,7 @@ class RangeSlider extends Component {
       incrementSize
     } = this.props
 
-    if (!isFinite(incrementSize)) return 0;
+    if (!isFinite(incrementSize) || incrementSize <= 0) return value;
     var e = 1, p = 0;
     while (Math.round(incrementSize * e) / e !== incrementSize) { e *= 10; p++; }
 
@@ -76,7 +76,7 @@ class RangeSlider extends Component {
     const padding = Math.ceil(markerSize / 2)
     const paddingStyles = { paddingLeft: padding, paddingRight: padding }
     const sliderLength = width - padding * 2
-    
+
     return (
       <View
         style={[styles.wrapper, paddingStyles]}

--- a/src/components/RangeSlider/index.js
+++ b/src/components/RangeSlider/index.js
@@ -141,7 +141,6 @@ class RangeSlider extends Component {
                       ? track.styles.bodyFont
                       : { fontFamily: _fonts.body }
                   }
-                  roundLabelValue={this.roundLabelValue}
                 />
               )
             }}


### PR DESCRIPTION
## Problem
When the slider component is set to increment size of 0.1 it will randomly jump to decimals between 0.1 like 1.10000002.

## Solution
Added a rounding function that filters the value before printing to the slider label. Magic text doesn't seem to have this issue ^ (when printing the slider values) so it seems the rounding is just a problem for the slider label.

Before:
<img width="457" alt="Screen Shot 2022-04-06 at 10 18 08 AM" src="https://user-images.githubusercontent.com/51417062/162009488-6d382553-fad4-4b40-ad09-aa27107b9f08.png">

After:
<img width="198" alt="Screen Shot 2022-04-06 at 10 19 38 AM" src="https://user-images.githubusercontent.com/51417062/162009504-a0e8a3a0-4927-46d7-a070-d8e671a1c47e.png">

## Additional Notes (optional)

- Link to [Trello](https://trello.com/c/l5ZbcxZO/315-slider-issue-with-01-increment-size)